### PR TITLE
updated slack link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ gtagId: "G-3V6VPT445S"
 
 network:
   linkedin: https://www.linkedin.com/company/womencodingcommunity
-  slack: https://join.slack.com/t/womencodingcommunity/shared_invite/zt-31h8amjsg-zojz1nO3YMpzab8MJUFxEA
+  slack: https://bit.ly/WCC-slack-invite
   github: https://github.com/Women-Coding-Community
   meetup: https://www.meetup.com/women-coding-community/
   instagram: https://www.instagram.com/women_coding_community


### PR DESCRIPTION
## Description
Current Slack invite link in footer does not work anymore, it either expired or was used by the maximum number of people allowed on Slack Free plan (400).

This PR updates the link to use a redirect URL (bit.ly) for better invite link management.
The invite links can then be managed/changed via Bitly without needing to update the website (login with womencodingcommunity account)

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [x] Data Update
- [ ] Documentation
- [ ] Other


Updated slack link
## Screenshots
<img width="1332" height="638" alt="Screenshot 2025-09-26 114813" src="https://github.com/user-attachments/assets/991ab674-162a-48ca-96be-14c34a857551" />

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->