### PR TITLE
Fix: remove failing step in meetup import workflow

### DIFF
--- a/.github/workflows/import_meetup_events.yml
+++ b/.github/workflows/import_meetup_events.yml
@@ -57,17 +57,6 @@ jobs:
           labels: |
             automation, auto-approve
 
-      - name: Confirm only events.yml was modified
-        if: steps.create-pr.outputs.pull-request-number
-        run: |
-            MODIFIED_FILES=$(git diff --name-only)
-            echo "Modified files: $MODIFIED_FILES"
-            if echo "$MODIFIED_FILES" | grep -qv "^_data/events.yml$"; then
-              echo "ERROR: Unexpected files were modified"
-              exit 1
-            fi
-            echo "Only events.yml was modified as expected"
-
       - name: Wait for required checks
         if: steps.create-pr.outputs.pull-request-number
         run: |


### PR DESCRIPTION
## Description
This PR removes a step added to the import meetup workflow in #638 

the step was meant to validate that only `events.yml` file was modified but fails scheduled runs because the order of execution i.e the changes have already been committed and the PR created; but it's not necessary and can be removed since the workflow has been tested over time and it only modifies events.yml



## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Mentor Update
- [ ] Data Update
- [ ] Documentation
- [ ] Other


## Related Issue


## Screenshots

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [ ] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally 

<!--  Thanks for sending a pull request! -->