### PR TITLE
Remove the pull request trigger for the Summarise Meetup Events workflow

### DIFF
--- a/.github/workflows/summarise_upcoming_events.yml
+++ b/.github/workflows/summarise_upcoming_events.yml
@@ -1,8 +1,6 @@
 name: Summarise Upcoming Meetup Events
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened ]
   workflow_dispatch:
   schedule:
     - cron: '0 7 * * 1' # Monday at 7am GMT

--- a/tools/llm_meetup_summary/llm_event_summary.py
+++ b/tools/llm_meetup_summary/llm_event_summary.py
@@ -42,8 +42,8 @@ def get_date_of_event_iso(event):
     return event_date_formatted
 
 def _filter_future_events(events):
-    today = date.today().isoformat()
-    return [event for event in events if get_date_of_event_iso(event) > today]
+    today = date.today().isoformat().replace('-', '')
+    return [event for event in events if get_date_of_event_iso(event) >= today]
 
 def _validate_event(event):
     missing_fields = [field for field in REQUIRED_EVENT_FIELDS if field not in event]


### PR DESCRIPTION
The workflow fails from a forked branch due to the GitHub Action secrets not being available. We should remove the pull request trigger from the Action.

<img width="799" height="508" alt="Screenshot 2026-02-13 at 10 25 21" src="https://github.com/user-attachments/assets/105908bd-9d82-4774-911f-5dbe35e9d769" />
