### PR TITLE
Automated import of reviewed blog posts

### DIFF
--- a/_posts/2026-07-08-wcc-ai-learning-blog.html
+++ b/_posts/2026-07-08-wcc-ai-learning-blog.html
@@ -1,0 +1,50 @@
+---
+layout: post
+title: "WCC-AI-Learning-Blog"
+date: 2026-07-08
+author_name: "Sonika Janagill"
+author_role: "Lead Engineer"
+image: /assets/images/blog/2026-07-08-wcc-ai-learning-blog.png
+image_source: "Gemini Image, if we dont want actual faces in image, please let me know I have an alternative image"
+description: "How leading the WCC AI Learning Series taught me more than it taught anyone else, and why you should try it too."
+category: blog
+---
+
+<div class="text-justify">
+<p><em>How leading the WCC AI Learning Series taught me more than it taught anyone else, and why you should try it too.</em></p>
+<hr>
+<p>We have all been there: standing at the bottom of a massive technical mountain, looking up, and wondering how on earth we are going to climb it.</p>
+<p>Three years ago, I was handed a brand-new project involving Artificial Intelligence, Retrieval-Augmented Generation (RAG), and AI Agents. There was just one small catch: I had no professional AI experience, I was entirely new to Python, and I had never built a UI chatbot in my life. Coming from a 14-year background in enterprise Java and e-commerce, I felt like a complete novice again. I had to learn it properly and fast.</p>
+<p>So I did what most of us do. I opened a hundred tabs.</p>
+<p>The internet does not lack AI content; it drowns you in it. Half of what I found was so basic it stopped right where things got interesting. The other half assumed I already had a PhD. There was very little in between for someone who could code but had never built an agent. I wanted the applied side, agents and retrieval, not the maths of training models from scratch. Finding a clean path through all of it was harder than the actual coding.</p>
+<p>After a lot of trial and error, and a fair amount of broken code, a sequence finally clicked for me:</p>
+<p><strong><em>LLM / AI APIs  -&gt;  RAG &amp; Embeddings  -&gt;  Agents  -&gt;  Multi-Agents &amp; Frameworks  -&gt;  Deployment &amp; Governance</em></strong></p>
+<p>Each step only made sense once the one before it had. That order was the thing I wished someone had handed me on day one.</p>
+<h2>The decision to teach it</h2>
+<p>I proposed the series because I knew I was not the only one drowning in that tab-soup of AI content. Plenty of engineers around me were in the same place: capable coders with no clear on-ramp to building real AI applications. <a href="https://www.linkedin.com/in/rajaniraog/">Rajani Rao</a>, my WCC mentor and Principal Technologist at AVEVA, encouraged me and backed it. Her backing is a huge reason I felt confident enough to step up to do the series and became a Lead here.</p>
+<p>By the time we ran the sessions, I had moved well past the basics. I had built things, broken things, and rebuilt them. I wasn't an expert in every corner of the field, but I made sure I wasn't just learning it the night before teaching it, either. The nuances of production AI code, edge cases, the moments where a pattern you thought you understood suddenly behaves differently: those came into sharper focus during the sessions themselves, partly from my own preparation and partly from the room.</p>
+<p>That last part surprised me more than anything. The group was not just WCC members. It brought new people into the community, including men and engineers from finance, healthcare, logistics, and product. Every domain brought a different way of seeing the same problem. A question from someone building document pipelines for a law firm reframes RAG in a way that no tutorial ever does. That cross-domain friction is where a lot of real learning happens, for everyone in the room, including the person at the front.</p>
+<p>I built the course around that exact sequence. <a href="https://www.linkedin.com/in/sonali-goel-tech/">Sonali</a>, WCC Lead, co-led with me: we split the six foundational sessions and ran them on alternate weeks, hands-on, themed entirely around real WCC problems rather than generic tutorials. A community info bot, a blog search system, and an event-planning agent. Things people could actually picture using.</p>
+<p>What I did not fully anticipate was how much the act of teaching sharpened my own thinking.</p>
+<h2>The part nobody tells you</h2>
+<p>There is a name for this. It is called the <strong>Protégé effect</strong>, and the research on it is surprisingly interesting. Studies have found that people who learn something with the intention of teaching it understand it more deeply than people who learn the same thing for a test, and the gap is widest on the hardest questions. One often-cited 2014 experiment found that simply expecting to teach changed how people engaged: they read more carefully, organised their thinking, and went looking for what really mattered. Seneca beat modern science to the punch by about two thousand years with just a few words: <strong>while we teach, we learn</strong>.</p>
+<p>That's exactly how I felt. You cannot wave your hands through a concept when people are watching you live-code it. The moment I had to explain why a RAG pipeline chunks documents the way it does, or what actually happens inside an agent's reasoning loop, every soft spot in my own understanding lit up. Preparing to teach forced me to close gaps I did not even know I had.</p>
+<p>I also learned a whole layer of skills that had nothing to do with AI. Sonali was brilliant on the operational side, the planning, the marketing, the way you actually run a community programme. Working alongside her, I picked up things I would never have learned by working heads-down on my own code. We built a genuine bond out of it, and I came away better at the parts of the job that no certification covers.</p>
+<p>And there was a meta-lesson hiding in plain sight. I used AI to help me teach AI. I drafted session outlines with it, worked up hands-on exercises and code, built slides, and leaned on NotebookLM to pull research and insights together. When a question nagged at me, I talked it through with a model before I ever stood in front of the group. Learning to teach with these tools, and to run a live session well, turned out to be a skill of its own.</p>
+<h2>How it pays you back</h2>
+<p>Here is the bit I most want you to hear, because it changed how I think about contributing at all.</p>
+<p>The series was never only a responsibility I took on for the community. It quietly worked in my favour too. The <a href="https://womencodingcommunity.slack.com/archives/C09L9C3FJP7">Slack</a> channel for the series is now a hundred people strong. The session videos are public on <a href="https://www.youtube.com/playlist?list=PLuFYQ1S7-bxsfbrkyv-b0DEgNkZT2ogma">YouTube</a>, and the <a href="https://github.com/Women-Coding-Community/ai-learning-series/">GitHub</a> repo is open for anyone to clone and learn from. That reach is real and lasting.</p>
+<p>Then it did something I genuinely did not plan. When I applied to become a Google Developer Expert in Cloud AI and Google Cloud, I submitted those very session recordings as part of my application. They counted and were evidence of the kind of technical depth and community impact the programme looks for. I am now a GDE, and a chunk of that case was built from teaching I had already done for the love of it.</p>
+<p>That is the point. Contributing is not a one-way donation of your time. Teach a topic, and you understand it better. Run a session, and you learn how to run sessions. Build something public, and it becomes a portfolio. Help a community, and it can open doors you were not even knocking on. One act, many returns. You do not have to be a world expert to start.</p>
+<h2>We are doing it again, and we want you in it</h2>
+<p>The series is relaunching in July with a fresh set of topics, and this time the community voted on what we cover. We are moving to standalone monthly sessions, hands-on as always, starting with agentic IDEs and tools like Antigravity CLI, then small models you can self-host, then bringing AI into the software development lifecycle.</p>
+<p>You can join in whatever way fits. Come and learn. Help review someone's code in <a href="https://github.com/Women-Coding-Community/ai-learning-series">GitHub</a>. Co-run a session. Write up what you built. Suggest the next topic on <a href="https://womencodingcommunity.slack.com/archives/C09L9C3FJP7">WCC Slack</a>. Every one of those makes the AI learning better, and I promise it gives more back to you than it takes.</p>
+<p>I started this not as an expert, but as someone who had done the hard work of finding a path and wanted to make that path easier for the next person. That is reason enough to begin.</p>
+<p>Come and learn out loud with us.</p>
+<hr>
+<p><em>Sonika Janagill is a Lead Backend Engineer at VML Enterprise Solutions and a Google Developer Expert in Cloud AI and Google Cloud. She leads the AI Learning Series at the Women Coding Community.</em> </p>
+<p>LinkedIn: <a href="https://www.linkedin.com/in/sonikaj/">https://www.linkedin.com/in/sonikaj/</a> </p>
+<p>Website: <a href="https://sonikajanagill.com/">https://sonikajanagill.com/</a> </p>
+<p>Medium: <a href="https://medium.sonikajanagill.com/">https://medium.sonikajanagill.com/</a> </p>
+<hr>
+</div>

--- a/_posts/2026-07-08-wcc-ai-learning-blog.html
+++ b/_posts/2026-07-08-wcc-ai-learning-blog.html
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "WCC-AI-Learning-Blog"
+title: "The best way to learn AI? Teach it."
 date: 2026-07-08
 author_name: "Sonika Janagill"
 author_role: "Lead Engineer"
 image: /assets/images/blog/2026-07-08-wcc-ai-learning-blog.png
-image_source: "Gemini Image, if we dont want actual faces in image, please let me know I have an alternative image"
+image_source: "Gemini Image"
 description: "How leading the WCC AI Learning Series taught me more than it taught anyone else, and why you should try it too."
-category: blog
+category: tech
 ---
 
 <div class="text-justify">


### PR DESCRIPTION
This PR was created automatically by a GitHub Action.

It contains every blog marked `isReviewedandApproved` (and not yet
`isPublished`) in the submissions spreadsheet:
- new posts under `_posts/`
- cover images under `assets/images/blog/`

The spreadsheet's `isPublished` column has already been set to TRUE for
these rows. Please review the rendered posts before merging.

If you close this PR **without merging**, reset `isPublished` to
FALSE in the spreadsheet for these rows — otherwise they won't be
re-exported and the blogs will be silently dropped.

<img width="1401" height="804" alt="Screenshot 2026-07-08 at 22 11 34" src="https://github.com/user-attachments/assets/c48f1d28-188e-4cd6-ad24-52c045b61dcb" />
<img width="934" height="811" alt="Screenshot 2026-07-08 at 22 11 46" src="https://github.com/user-attachments/assets/c6c1276c-67e7-450b-bf9b-54459bfa9ee3" />
<img width="928" height="822" alt="Screenshot 2026-07-08 at 22 11 56" src="https://github.com/user-attachments/assets/d83784ee-ae1e-4a0a-859c-d6988b06545a" />
<img width="942" height="808" alt="Screenshot 2026-07-08 at 22 12 05" src="https://github.com/user-attachments/assets/bd6969e3-8251-46e8-9b56-2643527629c0" />
<img width="880" height="827" alt="Screenshot 2026-07-08 at 22 12 14" src="https://github.com/user-attachments/assets/ba4bc5b2-72d1-4dc0-9b02-14767a4ed4cb" />
<img width="919" height="824" alt="Screenshot 2026-07-08 at 22 12 23" src="https://github.com/user-attachments/assets/8c8f47c1-f5d5-4cdd-bd5e-fdf14fbdb456" />
<img width="889" height="373" alt="Screenshot 2026-07-08 at 22 12 30" src="https://github.com/user-attachments/assets/c5f5c809-17e8-442d-952d-f9d759553916" />
